### PR TITLE
Handle card view toggle outside of card

### DIFF
--- a/SCENES/LARVAE/card_handler.tscn
+++ b/SCENES/LARVAE/card_handler.tscn
@@ -13,3 +13,6 @@ script = ExtResource("1_pyj0o")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1133166408]
 shape = SubResource("CircleShape2D_fpbf4")
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]
+[connection signal="body_exited" from="." to="." method="_on_body_exited"]

--- a/SCENES/LARVAE/larva_card.tscn
+++ b/SCENES/LARVAE/larva_card.tscn
@@ -11,7 +11,7 @@
 atlas = ExtResource("2_wnpqk")
 region = Rect2(184, 0, 184, 256)
 
-[sub_resource type="Resource" id="Resource_lmto1"]
+[sub_resource type="Resource" id="Resource_c5vmk"]
 resource_local_to_scene = true
 script = ExtResource("6_c5vmk")
 metadata/_custom_type_script = "uid://cxpts1at6sxjr"
@@ -21,6 +21,10 @@ radius = 1.0
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_wnpqk"]
 size = Vector2(184, 256)
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_lmto1"]
+radius = 26.0
+height = 152.0
 
 [node name="LarvaCard" type="Node2D" unique_id=1227121871 node_paths=PackedStringArray("ability_slots")]
 script = ExtResource("1_icnma")
@@ -57,7 +61,7 @@ collision_mask = 16
 
 [node name="Larva" parent="LarvaSlot" unique_id=1438854672 instance=ExtResource("1_4xgy5")]
 z_index = 0
-info = SubResource("Resource_lmto1")
+info = SubResource("Resource_c5vmk")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="LarvaSlot" unique_id=2083541082]
 shape = SubResource("CircleShape2D_icnma")
@@ -66,9 +70,13 @@ shape = SubResource("CircleShape2D_icnma")
 collision_layer = 8
 collision_mask = 16
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="ClickableArea" unique_id=1075871762]
+[node name="CardViewCollisionShape" type="CollisionShape2D" parent="ClickableArea" unique_id=1075871762]
 shape = SubResource("RectangleShape2D_wnpqk")
 
-[connection signal="body_entered" from="LarvaSlot" to="." method="_on_larva_slot_body_entered"]
-[connection signal="body_exited" from="LarvaSlot" to="." method="_on_larva_slot_body_exited"]
+[node name="LarvaViewCollisionShape" type="CollisionShape2D" parent="ClickableArea" unique_id=1015897179]
+position = Vector2(-7, -60)
+rotation = 1.5707964
+shape = SubResource("CapsuleShape2D_lmto1")
+disabled = true
+
 [connection signal="input_event" from="ClickableArea" to="." method="_on_clickable_area_input_event"]

--- a/SCENES/TERRARIUM/terrarium_station.tscn
+++ b/SCENES/TERRARIUM/terrarium_station.tscn
@@ -145,7 +145,7 @@ texture = SubResource("PlaceholderTexture2D_bnkvk")
 region_enabled = true
 region_rect = Rect2(0, 0, 1280, 224)
 
-[node name="CardHand" parent="CardSection" unique_id=1587952838 instance=ExtResource("10_04exf")]
+[node name="CardHand" parent="CardSection" unique_id=1587952838 groups=["card_hand"] instance=ExtResource("10_04exf")]
 position = Vector2(-96, 61)
 
 [node name="CardHandler" parent="." unique_id=2084620106 instance=ExtResource("2_04exf")]

--- a/SCRIPTS/GUI/DeckScreen/deck_view.gd
+++ b/SCRIPTS/GUI/DeckScreen/deck_view.gd
@@ -22,6 +22,7 @@ func add_card(larva_card: LarvaCard, force_slot: bool = false) -> bool:
 	for slot in deck_grid.get_children():
 		if slot is CardSlot:
 			if slot.add_card(larva_card):
+				larva_card.toggle_larva_view(false)
 				return true
 	
 	if force_slot:

--- a/SCRIPTS/GUI/DeckScreen/petri_dish.gd
+++ b/SCRIPTS/GUI/DeckScreen/petri_dish.gd
@@ -37,8 +37,9 @@ func add_larva_card(new_larva_card: LarvaCard):
 			new_larva_card.reparent(self, false)
 		else:
 			add_child(new_larva_card)
+		new_larva_card.toggle_larva_view(true)
 		
-		new_larva_card.position += larva_slot.position - new_larva_card.larva_slot.position
+		new_larva_card.position += larva_slot.position
 		larva_card = new_larva_card
 		larva = larva_card.larva
 		larva_card_added.emit(larva_card)

--- a/SCRIPTS/LARVAE/card_hand.gd
+++ b/SCRIPTS/LARVAE/card_hand.gd
@@ -48,6 +48,7 @@ func add_card(card: LarvaCard):
 		card.reparent(self)
 	else:
 		add_child(card)
+	card.toggle_larva_view(false)
 	
 	update_cards()
 

--- a/SCRIPTS/LARVAE/card_handler.gd
+++ b/SCRIPTS/LARVAE/card_handler.gd
@@ -6,6 +6,9 @@ var card : LarvaCard
 var card_start_global_transform : Transform2D
 var card_start_z : int
 var card_start_parent : Node
+var card_offset : Vector2
+
+var drop_target : Node2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -15,7 +18,12 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	global_position = global_position.lerp(get_viewport().get_mouse_position(), .5)
 	if card:
-		card.global_position = global_position
+		card.toggle_larva_view(is_instance_valid(drop_target))
+		if card.is_larva_view():
+			card_offset = -card.larva_slot.position
+		else:
+			card_offset = Vector2.ZERO
+		card.global_position = global_position + card_offset
 
 func _on_card_clicked(clicked_card: LarvaCard, button_index: MouseButton) -> void:
 	if not is_instance_valid(card):
@@ -28,9 +36,26 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		if event.is_released():
 			if event.button_index == MOUSE_BUTTON_LEFT and card:
-				if not card.drop():
-					if card_start_parent.has_method("add_card"):
-						card_start_parent.add_card(card)
-					else:
-						card.reparent(card_start_parent, false)
+				if not card.drop(drop_target):
+					if not card.drop(card_start_parent):
+						var card_container = get_tree().get_first_node_in_group("card_hand")
+						if card_container is CardHand:
+							card_container.add_card(card)
+						else:
+							card_container = get_tree().get_first_node_in_group("card_container")
+							if card_container is DeckView:
+								card_container.add_card(card, true)
+							else:
+								card.queue_free()
 				card = null
+
+func _on_body_entered(body: Node2D) -> void:
+	var body_parent = body.get_parent()
+	if body_parent is Terrarium:
+		drop_target = body_parent
+	else:
+		drop_target = body
+
+func _on_body_exited(body: Node2D) -> void:
+	if (body.get_parent() is Terrarium and body.get_parent() == drop_target) or body == drop_target:
+		drop_target = null

--- a/SCRIPTS/LARVAE/larva_card.gd
+++ b/SCRIPTS/LARVAE/larva_card.gd
@@ -9,15 +9,16 @@ signal died
 @onready var larva: Larva = $LarvaSlot/Larva
 @onready var card: Node2D = $Card
 @export var ability_slots : Array[CardAbilitySlot]
+@onready var card_view_collision_shape: CollisionShape2D = $ClickableArea/CardViewCollisionShape
+@onready var larva_view_collision_shape: CollisionShape2D = $ClickableArea/LarvaViewCollisionShape
 
-var drop_target : Node2D
 var grabbed
 
 func _ready() -> void:
 	load_larva_abilities()
 
 func _process(delta: float) -> void:
-	toggle_larva_view(is_instance_valid(drop_target))
+	toggle_larva_view(is_larva_view())
 
 func load_from_larva(new_larva: Larva):
 	if not is_node_ready():
@@ -33,12 +34,18 @@ func load_from_larva_info(new_larva_info: LarvaInfo):
 	load_larva_abilities()
 
 func toggle_larva_view(is_larva: bool):
+	card_view_collision_shape.disabled = is_larva
+	larva_view_collision_shape.disabled = not is_larva
+	
 	if is_larva:
 		larva.scale /= larva_slot.scale
 		card.hide()
 	else:
 		larva.scale *= larva_slot.scale
 		card.show()
+
+func is_larva_view() -> bool:
+	return not card.visible
 
 func _on_clickable_area_input_event(viewport: Node, event: InputEvent, shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.is_pressed():
@@ -47,7 +54,7 @@ func _on_clickable_area_input_event(viewport: Node, event: InputEvent, shape_idx
 func get_larva() -> Larva:
 	return larva
 
-func drop():
+func drop(drop_target : Node2D):
 	if is_instance_valid(drop_target):
 		if drop_target.has_method("add_larva_card"):
 			if drop_target.add_larva_card(self):
@@ -62,17 +69,6 @@ func drop():
 func die():
 	get_parent().remove_child(self)
 	died.emit()
-
-func _on_larva_slot_body_entered(body: Node2D) -> void:
-	var body_parent = body.get_parent()
-	if body_parent is Terrarium:
-		drop_target = body_parent
-	else:
-		drop_target = body
-
-func _on_larva_slot_body_exited(body: Node2D) -> void:
-	if (body.get_parent() is Terrarium and body.get_parent() == drop_target) or body == drop_target:
-		drop_target = null
 
 func load_larva_abilities():
 	if not larva.is_node_ready():

--- a/SCRIPTS/TERRARIUM/terrarium.gd
+++ b/SCRIPTS/TERRARIUM/terrarium.gd
@@ -99,8 +99,8 @@ func get_material_cell_at(global_pos: Vector2):
 func get_material_cell_center(material_cell: Vector2i):
 	return to_global(material_layer.map_to_local(material_cell))
 
-func add_larva(new_larva: Larva) -> bool:
-	if not larvae_running and larvae_container.get_children().size() < larvae_limit:
+func add_larva(new_larva: Larva, force: bool = false) -> bool:
+	if force or (not larvae_running and larvae_container.get_children().size() < larvae_limit):
 		if is_instance_valid(new_larva.get_parent()):
 			new_larva.reparent(larvae_container, true)
 		else:
@@ -111,6 +111,21 @@ func add_larva(new_larva: Larva) -> bool:
 		
 		if start_larvae_on_drop:
 			new_larva.start_making_bead()
+		
+		return true
+	return false
+	
+func add_larva_card(new_larva_card: LarvaCard) -> bool:
+	if not larvae_running and larvae_container.get_children().size() < larvae_limit:
+		if is_instance_valid(new_larva_card.get_parent()):
+			new_larva_card.reparent(larvae_container, true)
+		else:
+			larvae_container.add_child(new_larva_card)
+		
+		new_larva_card.toggle_larva_view(true)
+		
+		if start_larvae_on_drop:
+			return add_larva(new_larva_card.larva)
 		
 		return true
 	return false
@@ -126,7 +141,11 @@ func _on_larva_died(larva: Larva):
 func start_larvae(round_length: float = 0.0) -> bool:
 	if larvae_container.get_child_count() >= larvae_limit:
 		for node in larvae_container.get_children():
-			if node is Larva:
+			if node is LarvaCard:
+				if add_larva(node.larva, true):
+					node.larva.start_making_bead()
+					node.queue_free()
+			elif node is Larva:
 				larvae_running = true
 				node.start_making_bead()
 		

--- a/project.godot
+++ b/project.godot
@@ -59,6 +59,7 @@ shop_buttons=""
 camera=""
 larvae=""
 materials=""
+card_hand=""
 
 [gui]
 


### PR DESCRIPTION
Reparenting the card caused a single-frame flicker of card view due to brief exit then enter of collision area detecting if over drop target